### PR TITLE
Fixed codeexample inconsistency in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ const drawer = new PerlinDrawer2D(generator, (value: number) => {
         ex.Color.Blue,
         ex.Color.Violet
     ]
-    const colorIndex = Math.floor((val * rainbow.length));
+    const colorIndex = Math.floor((value * rainbow.length));
     return rainbow[colorIndex];
 });
 
@@ -84,7 +84,7 @@ const drawer = new PerlinDrawer2D(generator, (value: number) => {
         ex.Color.Blue,
         ex.Color.Violet
     ]
-    const colorIndex = Math.floor((val * rainbow.length));
+    const colorIndex = Math.floor((value * rainbow.length));
     return rainbow[colorIndex];
 });
 


### PR DESCRIPTION
The code examples mix the usage of `value` and `val` for the same variable. Changed everything to `value`